### PR TITLE
jenkins/build.jpl: add build-meta.json file

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -104,6 +104,7 @@ publish_kernel \
 --kdir=${kdir} \
 --token=${SECRET} \
 --api=${params.KCI_API_URL} \
+--json-path=build-meta.json \
 """)
         }
     }


### PR DESCRIPTION
Add build-meta.json file to being able to use it to generate job
templete files locally without having to crafting it by hand or
rebuilding the kernel from scratch.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>